### PR TITLE
fix: remove workaround for exit of spendie

### DIFF
--- a/tests/8_breeding.js
+++ b/tests/8_breeding.js
@@ -180,27 +180,7 @@ module.exports = async function(env) {
   const rsp = await node.send('eth_getTransactionReceipt', [condTx.hash()]);
   assert(rsp.logs && rsp.logs.length > 0, 'no events emitted');
 
-  unspents = (await node.getUnspent(minter, nstColor));
   log('-----------------unspents--------------');
-  log(unspents);
-  log('what a bullshit, circumventing proof bug with youngestInputIndex > 0');
-  transferTx = Tx.transfer(
-    [
-      new Input({
-        prevout: new Outpoint(unspents[0].outpoint.hash, unspents[0].outpoint.index),
-      }),
-    ],
-    [
-      new Output(
-        unspents[0].output.value,
-        minter,
-        unspents[0].output.color,
-        unspents[0].output.data,
-      ),
-    ],
-  );
-  transferTx.signAll(minterPriv);
-  await node.sendTx(transferTx);
   await minePeriod(env);
 
   unspents = (await node.getUnspent(minter, nstColor));


### PR DESCRIPTION
This PR removes a workaround to prevent failure of spendie exit (see https://github.com/leapdao/leap-contracts/pull/252 for details about the issue).

`startExit` was failing for spending condition tx and the workaround was to make an extra transfer from spendie and then exit that new UTXO (of transfer tx).
Without the workaround, the test is exiting an UTXO of the spending condition tx itself.